### PR TITLE
added missing ROS dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ if(NOT DISABLE_ROS)
     image_geometry
     image_transport
     angles
-    std_srvs
+    visualization_msgs
     tf
   )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ if(NOT DISABLE_ROS)
     message_filters
     image_geometry
     image_transport
+    angles
     tf
   )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ if(NOT DISABLE_ROS)
     image_geometry
     image_transport
     angles
+    std_srvs
     tf
   )
 

--- a/package.xml
+++ b/package.xml
@@ -23,6 +23,7 @@
   <build_depend>angles</build_depend>
   <build_depend>std_srvs</build_depend>
   <build_depend>tf</build_depend>
+  <build_depend>visualization_msgs</build_depend>
 
   <run_depend>message_runtime</run_depend>
   <run_depend>cv_bridge</run_depend>
@@ -33,5 +34,6 @@
   <run_depend>image_geometry</run_depend>
   <run_depend>angles</run_depend>
   <run_depend>std_srvs</run_depend>
+  <run_depend>visualization_msgs</run_depend>
   <run_depend>tf</run_depend>
 </package>

--- a/package.xml
+++ b/package.xml
@@ -20,6 +20,7 @@
   <build_depend>std_msgs</build_depend>
   <build_depend>camera_info_manager</build_depend>
   <build_depend>image_geometry</build_depend>
+  <build_depend>tf</build_depend>
 
   <run_depend>message_runtime</run_depend>
   <run_depend>cv_bridge</run_depend>
@@ -28,4 +29,5 @@
   <run_depend>std_msgs</run_depend>
   <run_depend>camera_info_manager</run_depend>
   <run_depend>image_geometry</run_depend>
+  <run_depend>tf</run_depend>
 </package>

--- a/package.xml
+++ b/package.xml
@@ -18,10 +18,12 @@
   <build_depend>roscpp</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>std_msgs</build_depend>
+  <build_depend>camera_info_manager</build_depend>
 
   <run_depend>message_runtime</run_depend>
   <run_depend>cv_bridge</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>std_msgs</run_depend>
+  <run_depend>camera_info_manager</run_depend>
 </package>

--- a/package.xml
+++ b/package.xml
@@ -19,6 +19,7 @@
   <build_depend>sensor_msgs</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>camera_info_manager</build_depend>
+  <build_depend>image_geometry</build_depend>
 
   <run_depend>message_runtime</run_depend>
   <run_depend>cv_bridge</run_depend>
@@ -26,4 +27,5 @@
   <run_depend>sensor_msgs</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>camera_info_manager</run_depend>
+  <run_depend>image_geometry</run_depend>
 </package>

--- a/package.xml
+++ b/package.xml
@@ -21,6 +21,7 @@
   <build_depend>camera_info_manager</build_depend>
   <build_depend>image_geometry</build_depend>
   <build_depend>angles</build_depend>
+  <build_depend>std_srvs</build_depend>
   <build_depend>tf</build_depend>
 
   <run_depend>message_runtime</run_depend>
@@ -31,5 +32,6 @@
   <run_depend>camera_info_manager</run_depend>
   <run_depend>image_geometry</run_depend>
   <run_depend>angles</run_depend>
+  <run_depend>std_srvs</run_depend>
   <run_depend>tf</run_depend>
 </package>

--- a/package.xml
+++ b/package.xml
@@ -20,6 +20,7 @@
   <build_depend>std_msgs</build_depend>
   <build_depend>camera_info_manager</build_depend>
   <build_depend>image_geometry</build_depend>
+  <build_depend>angles</build_depend>
   <build_depend>tf</build_depend>
 
   <run_depend>message_runtime</run_depend>
@@ -29,5 +30,6 @@
   <run_depend>std_msgs</run_depend>
   <run_depend>camera_info_manager</run_depend>
   <run_depend>image_geometry</run_depend>
+  <run_depend>angles</run_depend>
   <run_depend>tf</run_depend>
 </package>


### PR DESCRIPTION
The ROS version was missing quite a few dependencies to make this package releasable via the normal ROS deployment process. We will build Ubuntu packages for this from the https://github.com/LCAS/whycon fork. @gestom fixed a few missing dependencies in our fork and here is a PR to get those changes back upstream (bare any other smaller changes due to the release process), should you wish.
