### PR TITLE
added missing install targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,7 @@ if(NOT DISABLE_ROS)
     DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
   )
   ## Mark executables and/or libraries for installation
-  install(TARGETS whycon
+  install(TARGETS whycon whycon-node triangulator robot_pose_publisher
     ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
     LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
     RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}


### PR DESCRIPTION
Another small PR on top of #8 

This one adds the missing install targets, as originally the build binaries were not installed, and hence not released.

Regarding the release procedure that @v01d asked about in #8:

We have our [own ROS Ubuntu repository](https://github.com/strands-project-releases/strands-releases/wiki), releasing packages from our research centre and the STRANDS project. The official ROS release processes can be slow and not everything we release is yet supported on all ROS platforms. Hence, we release our own distribution of ROS packages, replicating the ROS build farm to some extend (and with some additional feature added) using our continuous integration infrastructure at https://lcas.lincoln.ac.uk/jenkins/. So, I have not released whycon into the official ROS distribution, I'd leave this to you, but the changes I submitted in #8 and this PR are required for it to be released should you ever wish to. Instead I have released whycon into _our_ repository from our fork: https://lcas.lincoln.ac.uk/jenkins/search/?q=whycon

I'd keep it as it is without prefix, because as soon as you release it "officially" the package with the higher version number will take precedence, no matter if it's from our or the official repo, hence the migration is transparent.

Hope this is ok.
