### PR TITLE
allowing to set the number of targets during reset

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,11 @@ if(NOT DISABLE_ROS)
     PointArray.msg
   )
 
+  add_service_files(
+    FILES
+    SetNumberOfTargets.srv
+  )
+
   generate_messages(
     DEPENDENCIES geometry_msgs
   )

--- a/src/ros/whycon_ros.cpp
+++ b/src/ros/whycon_ros.cpp
@@ -68,9 +68,11 @@ void whycon::WhyConROS::on_image(const sensor_msgs::ImageConstPtr& image_msg, co
   }
 }
 
-bool whycon::WhyConROS::reset(std_srvs::Empty::Request& request, std_srvs::Empty::Response& response)
+bool whycon::WhyConROS::reset(whycon::SetNumberOfTargets::Request& request, whycon::SetNumberOfTargets::Response& response)
 {
   should_reset = true;
+  targets = (int)request.number;
+  system = 0;
   return true;
 }
 

--- a/src/ros/whycon_ros.h
+++ b/src/ros/whycon_ros.h
@@ -5,7 +5,7 @@
 #include <cv_bridge/cv_bridge.h>
 #include <image_transport/image_transport.h>
 #include <image_geometry/pinhole_camera_model.h>
-#include <std_srvs/Empty.h>
+#include "whycon/SetNumberOfTargets.h"
 
 namespace whycon {
   class WhyConROS {
@@ -13,7 +13,7 @@ namespace whycon {
       WhyConROS(ros::NodeHandle& n);
 
       void on_image(const sensor_msgs::ImageConstPtr& image_msg, const sensor_msgs::CameraInfoConstPtr& info_msg);
-      bool reset(std_srvs::Empty::Request& request, std_srvs::Empty::Response& response);
+      bool reset(whycon::SetNumberOfTargets::Request& request, whycon::SetNumberOfTargets::Response& response);
 
     private:
       void publish_results(const std_msgs::Header& header, const cv_bridge::CvImageConstPtr& cv_ptr);

--- a/srv/SetNumberOfTargets.srv
+++ b/srv/SetNumberOfTargets.srv
@@ -1,0 +1,2 @@
+int64 number
+---


### PR DESCRIPTION
This is my attempt to allow a variable number of targets modifying the `reset` service.
Unfortunately, I'm not confident enough to implement this new feature while preserving backward compatibility. But I guess, the author or maintainer of this repository can easily build upon my suggestion.

(related to Issue #11)