### PR TITLE
Changed Deprecated Macro

### DIFF
--- a/src/ros/whycon_nodelet.cpp
+++ b/src/ros/whycon_nodelet.cpp
@@ -15,6 +15,6 @@ namespace whycon {
   };
 }
 
-PLUGINLIB_DECLARE_CLASS(whycon, WhyconNodelet, whycon::WhyconNodelet, nodelet::Nodelet)
+PLUGINLIB_EXPORT_CLASS(whycon::WhyconNodelet, nodelet::Nodelet)
 
 


### PR DESCRIPTION
Changed the macro PLUGINLIB_DECLARE_CLASS to PLUGINLIB_EXPORT_CLASS, for a successful build in ROS Melodic.